### PR TITLE
chore: add Python security and quality pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,57 +1,55 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
         args: ['--unsafe']
         exclude: 'ssm-doc-pr-validate\.yml$'
+      - id: check-toml
       - id: check-json
       - id: check-added-large-files
+        args: ['--maxkb=500']
       - id: check-merge-conflict
       - id: detect-private-key
       - id: check-ast
       - id: debug-statements
-      - id: name-tests-test
-        args: ['--pytest-test-first']
 
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.5
     hooks:
-      - id: black
-        language_version: python3
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ['--profile', 'black']
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-        args: ['--max-line-length=88', '--extend-ignore=E203,W503']
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.19.1
     hooks:
       - id: mypy
-        additional_dependencies: [types-PyYAML, types-jsonschema]
+        args: [--ignore-missing-imports]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
+    rev: 1.9.4
     hooks:
       - id: bandit
         args: ['-c', 'pyproject.toml']
         additional_dependencies: ['bandit[toml]']
 
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.10.0
     hooks:
-      - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+      - id: pip-audit
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.23.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.11
+    hooks:
+      - id: actionlint
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- Adds/upgrades pre-commit hooks for code quality and security scanning
- Tools: ruff (lint/format), mypy (type check), bandit (SAST), pip-audit (CVE scan), gitleaks (secret detection), actionlint (CI lint)
- Replaces black/isort/flake8 with ruff, upgrades pre-commit-hooks to v6.0.0
- Retains repo-specific local hooks (yamllint, ssm-policy-check, ssm-schema-validate)

## Test plan
- [ ] Run `pre-commit run --all-files` locally
- [ ] Verify no false positives block development

Refs #1